### PR TITLE
Add option to decide if an error should be considered a failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ the number of failures allowed before the Breaker enters the `open` state.
 ##### `resetTimeout`
 the amount of time to wait before switch the Breaker from the `open` to `half_open` state to attempt recovery.
 
+##### `isFailure`
+function that returns true if an error should be considered a failure (receives the error object returned by your command.) This allows for non-critical errors to be ignored by the circuit breaker.
+
 #### Properties
 ##### `fallback`
 a Breaker instance to fallback to in the case of the Breaker entering the `open` state.

--- a/lib/breaker.js
+++ b/lib/breaker.js
@@ -109,7 +109,7 @@ Breaker.prototype._run = function _run(/*args...n, callback*/) {
         self._pendingClose = false;
         self.emit('duration', Date.now() - start);
 
-        if (err) {
+        if (err && self.settings.isFailure(err)) {
             self.emit('failure', err);
             self._onFailure();
         } else {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -4,5 +4,8 @@
 exports.Breaker = {
     maxFailures: 5,
     timeout: 10000,
-    resetTimeout: 60000
+    resetTimeout: 60000,
+    isFailure: function () {
+      return true;
+    }
 };


### PR DESCRIPTION
Allows for non-critical errors to pass through the circuit breaker
without tripping it. An example is a 400 or 404 error returned by
a REST API call.